### PR TITLE
Fix: Make autocommands buffer-local

### DIFF
--- a/lua/clangd_extensions/inlay_hints.lua
+++ b/lua/clangd_extensions/inlay_hints.lua
@@ -40,7 +40,7 @@ function M.setup_autocmd()
     vim.api.nvim_command(
         "autocmd "
             .. events
-            .. ' *.c,*.cpp :lua require"clangd_extensions.inlay_hints".set_inlay_hints()'
+            .. ' <buffer> lua require"clangd_extensions.inlay_hints".set_inlay_hints()'
     )
     vim.api.nvim_command("augroup END")
 end


### PR DESCRIPTION
Rather than relying on file extension patterns to determine when inlay hints should be updated (which originally missed extensions like \*.cc, etc.), we should make a buffer-local autocommand. Buffer attachment to appropriate filetypes is already handled by the built-in LSP client, so this won't affect files that don't have clangd attached.
