### PR TITLE
add a option to control inlay hint priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ require("clangd_extensions").setup {
             right_align_padding = 7,
             -- The color of the hints
             highlight = "Comment",
+            -- The highlight group priority for extmark
+            priority = 100,
         },
         ast = {
             role_icons = {

--- a/lua/clangd_extensions/config.lua
+++ b/lua/clangd_extensions/config.lua
@@ -15,6 +15,7 @@ local defaults = {
             right_align = false,
             right_align_padding = 7,
             highlight = "Comment",
+            priority = 100,
         },
 
         ast = {

--- a/lua/clangd_extensions/inlay_hints.lua
+++ b/lua/clangd_extensions/inlay_hints.lua
@@ -212,6 +212,7 @@ local function handler(err, result, ctx)
                     { virt_text, config.options.extensions.inlay_hints.highlight },
                 },
                 hl_mode = "combine",
+                priority = config.options.extensions.inlay_hints.priority,
             })
 
             -- update state


### PR DESCRIPTION
the pr add a `priority` option to inlay hint configuration, so I can ensure inlay hints always appear before other marks e.g git blame. 

same as https://github.com/lewis6991/gitsigns.nvim/issues/513