### PR TITLE
Clear old autocommands on reload

### DIFF
--- a/lua/clangd_extensions/inlay_hints.lua
+++ b/lua/clangd_extensions/inlay_hints.lua
@@ -37,6 +37,7 @@ function M.setup_autocmd()
     end
 
     vim.api.nvim_command("augroup ClangdInlayHints")
+    vim.api.nvim_command("au! * <buffer>")
     vim.api.nvim_command(
         "autocmd "
             .. events


### PR DESCRIPTION
Hi!

I noticed that reloading a buffer duplicates the autocommands for updating inlay-hints, and would like to fix that :)
Thank you for the nice tool :+1: