### PR TITLE
Format with stylua, drop deprecated functions entirely, fix `vim.highlight.range()` args, etc.

### DIFF
--- a/lua/clangd_extensions/ast.lua
+++ b/lua/clangd_extensions/ast.lua
@@ -100,9 +100,11 @@ local function highlight_detail(ast_buf)
             conf.highlights.detail,
             { linenum - 1, range.start },
             { linenum - 1, range["end"] },
-            "v",
-            false,
-            110
+            {
+                regtype = "v",
+                inclusive = false,
+                priority = 110,
+            }
         )
     end
 end
@@ -157,9 +159,11 @@ function M.update_highlight(source_buf, ast_buf)
             "Search",
             curline_ranges.start,
             curline_ranges["end"],
-            "v",
-            false,
-            110
+            {
+                regtype = "v",
+                inclusive = false,
+                priority = 110,
+            }
         )
     end
 end

--- a/lua/clangd_extensions/inlay_hints.lua
+++ b/lua/clangd_extensions/inlay_hints.lua
@@ -142,7 +142,7 @@ local function handler(err, result, ctx)
     local max_len = -1
 
     for key, _ in pairs(ret) do
-        local line = tonumber(key)
+        local line = math.floor(tonumber(key))
         local current_line =
             vim.api.nvim_buf_get_lines(bufnr, line, line + 1, false)[1]
         if current_line then
@@ -153,7 +153,7 @@ local function handler(err, result, ctx)
 
     for key, value in pairs(ret) do
         local virt_text = ""
-        local line = tonumber(key)
+        local line = math.floor(tonumber(key))
 
         local current_line =
             vim.api.nvim_buf_get_lines(bufnr, line, line + 1, false)[1]

--- a/lua/clangd_extensions/memory_usage.lua
+++ b/lua/clangd_extensions/memory_usage.lua
@@ -5,8 +5,8 @@ local function display(lines)
     for k, line in pairs(lines) do -- Pad lines
         if k ~= 1 then lines[k] = "  " .. line .. "  " end
     end
-    local vim_width = api.nvim_get_option("columns")
-    local vim_height = api.nvim_get_option("lines")
+    local vim_width = api.nvim_get_option_value("columns", { scope = "local" })
+    local vim_height = api.nvim_get_option_value("lines", { scope = "local" })
     local height = math.ceil(vim_height * 0.7 - 4)
     local width = math.ceil(vim_width * 0.7)
     local row = math.ceil((vim_height - height) / 2 - 1)

--- a/lua/clangd_extensions/memory_usage.lua
+++ b/lua/clangd_extensions/memory_usage.lua
@@ -21,9 +21,9 @@ local function display(lines)
         col = col,
         border = require("clangd_extensions.config").options.memory_usage.border,
     })
-    vim.bo[buf].shiftwidth = 2
     vim.wo.foldmethod = "indent"
     api.nvim_buf_set_lines(buf, 0, -1, true, lines)
+    api.nvim_set_option_value("shiftwidth", 2, { buf = buf })
     api.nvim_set_option_value("bufhidden", "wipe", { buf = buf })
     api.nvim_set_option_value("modifiable", false, { buf = buf })
     api.nvim_set_option_value("buftype", "nofile", { buf = buf })

--- a/lua/clangd_extensions/memory_usage.lua
+++ b/lua/clangd_extensions/memory_usage.lua
@@ -21,19 +21,21 @@ local function display(lines)
         col = col,
         border = require("clangd_extensions.config").options.memory_usage.border,
     })
-    vim.bo.shiftwidth = 2
+    vim.bo[buf].shiftwidth = 2
     vim.wo.foldmethod = "indent"
     api.nvim_buf_set_lines(buf, 0, -1, true, lines)
     api.nvim_set_option_value("bufhidden", "wipe", { buf = buf })
     api.nvim_set_option_value("modifiable", false, { buf = buf })
     api.nvim_set_option_value("buftype", "nofile", { buf = buf })
-    api.nvim_buf_set_keymap(buf, "n", "q", ":bd<CR>", {
+    vim.keymap.set("n", "q", ":bd<CR>", {
         noremap = true,
         silent = true,
+        buffer = buf,
     })
-    api.nvim_buf_set_keymap(buf, "n", "<ESC>", ":bd<CR>", {
+    vim.keymap.set("n", "<ESC>", ":bd<CR>", {
         noremap = true,
         silent = true,
+        buffer = buf,
     })
 end
 

--- a/lua/clangd_extensions/switch_source_header.lua
+++ b/lua/clangd_extensions/switch_source_header.lua
@@ -14,12 +14,10 @@ local function handler(_err, uri)
     }, {})
 end
 
-local M = {}
-
-function M.switch_source_header()
-    vim.lsp.buf_request(0, "textDocument/switchSourceHeader", {
-        uri = vim.uri_from_bufnr(0),
-    }, handler)
-end
-
-return M
+return {
+    switch_source_header = function()
+        vim.lsp.buf_request(0, "textDocument/switchSourceHeader", {
+            uri = vim.uri_from_bufnr(0),
+        }, handler)
+    end,
+}

--- a/lua/clangd_extensions/switch_source_header.lua
+++ b/lua/clangd_extensions/switch_source_header.lua
@@ -1,6 +1,10 @@
 local function handler(_err, uri)
     if not uri or uri == "" then
-        vim.api.nvim_echo({ { "Corresponding file cannot be determined" } }, false, {})
+        vim.api.nvim_echo(
+            { { "Corresponding file cannot be determined" } },
+            false,
+            {}
+        )
         return
     end
     local file_name = vim.uri_to_fname(uri)

--- a/lua/clangd_extensions/switch_source_header.lua
+++ b/lua/clangd_extensions/switch_source_header.lua
@@ -14,10 +14,12 @@ local function handler(_err, uri)
     }, {})
 end
 
-return {
-    switch_source_header = function()
-        vim.lsp.buf_request(0, "textDocument/switchSourceHeader", {
-            uri = vim.uri_from_bufnr(0),
-        }, handler)
-    end,
-}
+local M = {}
+
+function M.switch_source_header()
+    vim.lsp.buf_request(0, "textDocument/switchSourceHeader", {
+        uri = vim.uri_from_bufnr(0),
+    }, handler)
+end
+
+return M

--- a/plugin/clangd_extensions.lua
+++ b/plugin/clangd_extensions.lua
@@ -1,42 +1,60 @@
 local create_command = vim.api.nvim_create_user_command
 
-create_command('ClangdSetInlayHints', function()
-    require("clangd_extensions.inlay_hints").set_inlay_hints()
-end, {})
-
-create_command('ClangdDisableInlayHints', function()
-    require("clangd_extensions.inlay_hints").disable_inlay_hints()
-end, {})
-
-create_command('ClangdToggleInlayHints', function()
-    require("clangd_extensions.inlay_hints").toggle_inlay_hints()
-end, {})
-
-create_command('ClangdAST', function(opts)
-    require("clangd_extensions.ast").display_ast(opts.line1, opts.line2)
-end, { range = true })
-
-create_command('ClangdTypeHierarchy', function()
-    require("clangd_extensions.type_hierarchy").show_hierarchy()
-end, {})
-
-create_command('ClangdSymbolInfo', function()
-    require("clangd_extensions.symbol_info").show_symbol_info()
-end, {})
+create_command(
+    "ClangdSetInlayHints",
+    function() require("clangd_extensions.inlay_hints").set_inlay_hints() end,
+    {}
+)
 
 create_command(
-    'ClangdMemoryUsage',
+    "ClangdDisableInlayHints",
+    function() require("clangd_extensions.inlay_hints").disable_inlay_hints() end,
+    {}
+)
+
+create_command(
+    "ClangdToggleInlayHints",
+    function() require("clangd_extensions.inlay_hints").toggle_inlay_hints() end,
+    {}
+)
+
+create_command(
+    "ClangdAST",
     function(opts)
-        require("clangd_extensions.memory_usage").show_memory_usage(opts.args == 'expand_preamble')
+        require("clangd_extensions.ast").display_ast(opts.line1, opts.line2)
+    end,
+    { range = true }
+)
+
+create_command(
+    "ClangdTypeHierarchy",
+    function() require("clangd_extensions.type_hierarchy").show_hierarchy() end,
+    {}
+)
+
+create_command(
+    "ClangdSymbolInfo",
+    function() require("clangd_extensions.symbol_info").show_symbol_info() end,
+    {}
+)
+
+create_command(
+    "ClangdMemoryUsage",
+    function(opts)
+        require("clangd_extensions.memory_usage").show_memory_usage(
+            opts.args == "expand_preamble"
+        )
     end,
     {
-        nargs = '?',
-        complete = function(_, _, _)
-            return { 'expand_preamble' }
-        end
+        nargs = "?",
+        complete = function(_, _, _) return { "expand_preamble" } end,
     }
 )
 
-create_command('ClangdSwitchSourceHeader', function()
-    require("clangd_extensions.switch_source_header").switch_source_header()
-end, {})
+create_command(
+    "ClangdSwitchSourceHeader",
+    function()
+        require("clangd_extensions.switch_source_header").switch_source_header()
+    end,
+    {}
+)


### PR DESCRIPTION
<div align="center">

## Changes

</div>

- Format with stylua
- Dropped use of deprecated code (see [my rationale](#rationale) below)
- ~~Rewrote `switch_source_header.lua` into local table for possible future extensions~~
- Corrected parameters for `vim.highlight.range()`
- Enforced variable types

### Rationale

Since this plugin relies on a lot of `nvim >=0.10` features I see no reason to further include deprecated
code further.
We might disagree on that. If so let me know and I shall revert these changes.

Anything else you need, tell me :)