### PR TITLE
Fix issue with inlay_hints when text is a `table`

### DIFF
--- a/lua/clangd_extensions/inlay_hints.lua
+++ b/lua/clangd_extensions/inlay_hints.lua
@@ -245,6 +245,9 @@ local function inline_handler(err, result, ctx)
 
     for _, hint in pairs(result) do
         local text = hint.label
+        if (type(text) == "table") then
+            text = text[1].value
+        end
         if hint.paddingLeft then text = " " .. text end
         if hint.paddingRight then text = text .. " " end
         local line = hint.position.line


### PR DESCRIPTION
The lsp return might have changed recently.

I'm not 100% sure this is the best place to put this fix. It's possible that the caller should be responsible for this. Depends really on the overall architecture.

This would fix naively [issue#66.](url)