### PR TITLE
Fixed deprecations, decreased complexity, used `client:request()`

### DIFF
--- a/lua/clangd_extensions/init.lua
+++ b/lua/clangd_extensions/init.lua
@@ -1,5 +1,5 @@
-return {
-    setup = function(options)
-        require("clangd_extensions.config").setup(options)
-    end,
-}
+local M = {}
+
+M.setup = require("clangd_extensions.config").setup
+
+return M

--- a/lua/clangd_extensions/memory_usage.lua
+++ b/lua/clangd_extensions/memory_usage.lua
@@ -1,5 +1,7 @@
 local api = vim.api
+local nvim_get_current_buf = api.nvim_get_current_buf
 local fmt = string.format
+local ceil = math.ceil
 
 local function display(lines)
     for k, line in pairs(lines) do -- Pad lines
@@ -7,10 +9,10 @@ local function display(lines)
     end
     local vim_width = api.nvim_get_option_value("columns", { scope = "local" })
     local vim_height = api.nvim_get_option_value("lines", { scope = "local" })
-    local height = math.ceil(vim_height * 0.7 - 4)
-    local width = math.ceil(vim_width * 0.7)
-    local row = math.ceil((vim_height - height) / 2 - 1)
-    local col = math.ceil((vim_width - width) / 2)
+    local height = ceil(vim_height * 0.7 - 4)
+    local width = ceil(vim_width * 0.7)
+    local row = ceil((vim_height - height) / 2 - 1)
+    local col = ceil((vim_width - width) / 2)
     local buf = api.nvim_create_buf(false, true)
     api.nvim_open_win(buf, true, {
         style = "minimal",
@@ -103,11 +105,11 @@ end
 local M = {}
 
 function M.show_memory_usage(expand_preamble)
-    vim.lsp.buf_request(
-        0,
+    require("clangd_extensions.utils").buf_request_method(
         "$/memoryUsage",
         nil,
-        function(err, result) handler(err, result, expand_preamble) end
+        function(err, result) handler(err, result, expand_preamble) end,
+        nvim_get_current_buf()
     )
 end
 

--- a/lua/clangd_extensions/switch_source_header.lua
+++ b/lua/clangd_extensions/switch_source_header.lua
@@ -1,3 +1,6 @@
+local api = vim.api
+local nvim_get_current_buf = api.nvim_get_current_buf
+
 local function handler(_err, uri)
     if not uri or uri == "" then
         vim.api.nvim_echo(
@@ -14,10 +17,18 @@ local function handler(_err, uri)
     }, {})
 end
 
-return {
-    switch_source_header = function()
-        vim.lsp.buf_request(0, "textDocument/switchSourceHeader", {
-            uri = vim.uri_from_bufnr(0),
-        }, handler)
-    end,
-}
+local M = {}
+
+function M.switch_source_header()
+    local bufnr = nvim_get_current_buf()
+    require("clangd_extensions.utils").buf_request_method(
+        "textDocument/switchSourceHeader",
+        {
+            uri = vim.uri_from_bufnr(bufnr),
+        },
+        handler,
+        bufnr
+    )
+end
+
+return M

--- a/lua/clangd_extensions/symbol_info.lua
+++ b/lua/clangd_extensions/symbol_info.lua
@@ -1,11 +1,16 @@
+local fmt = string.format
+local len = string.len
+local api = vim.api
+local nvim_get_current_buf = api.nvim_get_current_buf
+
 local function handler(err, result)
     if err or (#result == 0) then return end
-    local name_str = string.format("name: %s", result[1].name)
-    local container_str =
-        string.format("container: %s", result[1].containerName)
+    local name_str = fmt("name: %s", result[1].name)
+    local container_str = fmt("container: %s", result[1].containerName)
+
     vim.lsp.util.open_floating_preview({ name_str, container_str }, "", {
         height = 2,
-        width = math.max(string.len(name_str), string.len(container_str)),
+        width = math.max(len(name_str), len(container_str)),
         focusable = false,
         focus = false,
         border = require("clangd_extensions.config").options.symbol_info.border,
@@ -15,15 +20,22 @@ end
 local M = {}
 
 function M.show_symbol_info()
-    vim.lsp.buf_request(0, "textDocument/symbolInfo", {
-        textDocument = {
-            uri = vim.uri_from_bufnr(0),
+    local bufnr = nvim_get_current_buf()
+
+    require("clangd_extensions.utils").buf_request_method(
+        "textDocument/symbolInfo",
+        {
+            textDocument = {
+                uri = vim.uri_from_bufnr(bufnr),
+            },
+            position = {
+                line = vim.fn.getcurpos()[2] - 1,
+                character = vim.fn.getcurpos()[3] - 1,
+            },
         },
-        position = {
-            line = vim.fn.getcurpos()[2] - 1,
-            character = vim.fn.getcurpos()[3] - 1,
-        },
-    }, handler)
+        handler,
+        bufnr
+    )
 end
 
 return M

--- a/lua/clangd_extensions/type_hierarchy.lua
+++ b/lua/clangd_extensions/type_hierarchy.lua
@@ -1,6 +1,7 @@
 local symbol_kind = require("clangd_extensions.symbol_kind")
 local fmt = string.format
 local api = vim.api
+local nvim_get_current_buf = api.nvim_get_current_buf
 local type_hierarchy_augroup =
     api.nvim_create_augroup("ClangdTypeHierarchy", {})
 
@@ -17,19 +18,17 @@ local function format_tree(node, visited, result, padding, type_to_location)
 
     type_to_location[node.name] = { uri = node.uri, range = node.range }
 
-    if node.parents then
-        if #node.parents > 0 then
-            table.insert(result, padding .. "   Parents:")
-            for _, parent in pairs(node.parents) do
-                if not visited[parent.data] then
-                    format_tree(
-                        parent,
-                        visited,
-                        result,
-                        padding .. "   ",
-                        type_to_location
-                    )
-                end
+    if node.parents and #node.parents > 0 then
+        table.insert(result, padding .. "   Parents:")
+        for _, parent in pairs(node.parents) do
+            if not visited[parent.data] then
+                format_tree(
+                    parent,
+                    visited,
+                    result,
+                    padding .. "   ",
+                    type_to_location
+                )
             end
         end
     end
@@ -55,90 +54,97 @@ local function format_tree(node, visited, result, padding, type_to_location)
 end
 
 local function handler(err, TypeHierarchyItem, ctx)
-    if err or not TypeHierarchyItem then
-        return
-    else
-        -- Save old state
-        local source_win = api.nvim_get_current_win()
+    if err or not TypeHierarchyItem then return end
 
-        -- Init
-        M.offset_encoding[ctx.client_id] =
-            vim.lsp.get_client_by_id(ctx.client_id).offset_encoding
-        vim.cmd.split(fmt("%s: type hierarchy", TypeHierarchyItem.name))
-        local bufnr = vim.api.nvim_get_current_buf()
-        M.type_to_location[bufnr] = {}
+    local client_id = ctx.client_id
+    -- Save old state
+    local source_win = api.nvim_get_current_win()
 
-        -- Set content
-        local lines = format_tree(
-            TypeHierarchyItem,
-            {},
-            {},
-            "",
-            M.type_to_location[bufnr]
-        )
-        api.nvim_buf_set_lines(bufnr, 0, -1, true, lines)
+    -- Init
+    M.offset_encoding[client_id] = vim.lsp.get_clients({ id = client_id })[1].offset_encoding
+    vim.cmd.split(fmt("%s: type hierarchy", TypeHierarchyItem.name))
+    local bufnr = nvim_get_current_buf()
+    M.type_to_location[bufnr] = {}
 
-        -- Set options
-        vim.bo.modifiable = false
-        vim.bo.filetype = "ClangdTypeHierarchy"
-        vim.bo.buftype = "nofile"
-        vim.bo.bufhidden = "wipe"
-        vim.bo.buflisted = true
-        api.nvim_set_option_value("number", false, { scope = "local" })
-        api.nvim_set_option_value("relativenumber", false, { scope = "local" })
-        api.nvim_set_option_value("spell", false, { scope = "local" })
-        api.nvim_set_option_value("cursorline", false, { scope = "local" })
-        local winbar = api.nvim_get_option_value("winbar", {})
-        local numlines = winbar == "" and #lines or #lines + 1
-        local winheight = math.min(numlines, 15)
-        api.nvim_win_set_height(0, winheight)
+    -- Set content
+    local lines = format_tree(
+        TypeHierarchyItem,
+        {},
+        {},
+        "",
+        M.type_to_location[bufnr]
+    )
+    api.nvim_buf_set_lines(bufnr, 0, -1, true, lines)
 
-        -- Set highlights
-        vim.cmd([[
+    -- Set options
+    vim.bo.modifiable = false
+    vim.bo.filetype = "ClangdTypeHierarchy"
+    vim.bo.buftype = "nofile"
+    vim.bo.bufhidden = "wipe"
+    vim.bo.buflisted = true
+    api.nvim_set_option_value("number", false, { scope = "local" })
+    api.nvim_set_option_value("relativenumber", false, { scope = "local" })
+    api.nvim_set_option_value("spell", false, { scope = "local" })
+    api.nvim_set_option_value("cursorline", false, { scope = "local" })
+    local winbar = api.nvim_get_option_value("winbar", {})
+    local numlines = winbar == "" and #lines or #lines + 1
+    local winheight = math.min(numlines, 15)
+    api.nvim_win_set_height(0, winheight)
+
+    -- Set highlights
+    vim.cmd([[
         syntax clear
         syntax match ClangdTypeName "\( \{2,\}• \)\@<=\w\+\(:\)\@="
         ]])
-        vim.api.nvim_set_hl(0, "ClangdTypeName", { link = "Underlined" })
+    vim.api.nvim_set_hl(0, "ClangdTypeName", { link = "Underlined" })
 
-        -- Set keymap
-        vim.keymap.set("n", "gd", function()
-            local word = vim.fn.expand("<cWORD>")
-            word = string.gsub(word, ":$", "")
-            local location = M.type_to_location[bufnr][word]
-            if location ~= nil then
-                api.nvim_set_current_win(source_win)
-                vim.lsp.util.jump_to_location(
-                    location,
-                    M.offset_encoding[ctx.client_id]
-                )
-            end
-        end, {
-            buffer = bufnr,
-            desc = "go to definition of type under cursor",
-        })
+    -- Set keymap
+    vim.keymap.set("n", "gd", function()
+        local word = vim.fn.expand("<cWORD>")
+        word = string.gsub(word, ":$", "")
+        local location = M.type_to_location[bufnr][word]
+        if location ~= nil then
+            api.nvim_set_current_win(source_win)
 
-        -- Clear `type_to_location` for this buffer when it is wiped out
-        api.nvim_create_autocmd("BufWipeOut", {
-            buffer = bufnr,
-            group = type_hierarchy_augroup,
-            callback = function() M.type_to_location[bufnr] = nil end,
-        })
-    end
+            vim.lsp.util.show_document(
+                location,
+                M.offset_encoding[client_id],
+                { focus = true }
+            )
+        end
+    end, {
+        buffer = bufnr,
+        desc = "go to definition of type under cursor",
+    })
+
+    -- Clear `type_to_location` for this buffer when it is wiped out
+    api.nvim_create_autocmd("BufWipeOut", {
+        buffer = bufnr,
+        group = type_hierarchy_augroup,
+        callback = function() M.type_to_location[bufnr] = nil end,
+    })
 end
 
 function M.show_hierarchy()
-    vim.lsp.buf_request(0, "textDocument/typeHierarchy", {
-        textDocument = {
-            uri = vim.uri_from_bufnr(0),
+    local bufnr = nvim_get_current_buf()
+
+    require("clangd_extensions.utils").buf_request_method(
+        "textDocument/typeHierarchy",
+        {
+            textDocument = {
+                uri = vim.uri_from_bufnr(bufnr),
+            },
+            position = {
+                line = vim.fn.getcurpos()[2] - 1,
+                character = vim.fn.getcurpos()[3] - 1,
+            },
+            -- TODO make these configurable (config + command args)
+            resolve = 3,
+            direction = 2,
         },
-        position = {
-            line = vim.fn.getcurpos()[2] - 1,
-            character = vim.fn.getcurpos()[3] - 1,
-        },
-        -- TODO make these configurable (config + command args)
-        resolve = 3,
-        direction = 2,
-    }, handler)
+        handler,
+        bufnr
+    )
 end
 
 return M

--- a/lua/clangd_extensions/utils.lua
+++ b/lua/clangd_extensions/utils.lua
@@ -1,0 +1,10 @@
+local M = {}
+
+function M.buf_request_method(method, params, handler, bufnr)
+    local clients = vim.lsp.get_clients({ bufnr = bufnr, method = method })
+    for _, client in pairs(clients) do
+        client:request(method, params, handler, bufnr)
+    end
+end
+
+return M


### PR DESCRIPTION
## Changes

- Improved code formatting
- ~Switched from `vim.lsp.buf_request()` to `client:request()`~
- Made a custom module `utils.lua` that containing a replacement for `vim.lsp.buf_request()`
- `vim.lsp.util.jump_to_location()` is deprecated. Switched to `vim.lsp.util.show_document()` instead as directed by the docs
- Decreased code complexity
- (init) `setup()` is now a direct call to `config.setup()` instead of a wrapper
- Formatted with StyLua