### PR TITLE
ci: add optional `pre-commit` config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: stylua
+        name: StyLua
+        language: system
+        entry: stylua
+        types: [lua]
+        verbose: true


### PR DESCRIPTION
## Description

[`pre-commit`](https://pre-commit.com/) is useful for users that decide to use it
to get hooks to run on commit.

I've added a very useful hook for running StyLua in case formatting wasn't made.